### PR TITLE
debug_session: Ignore stop notifications if no stopped thread is found

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -1542,6 +1542,12 @@ impl DebugSession {
                 }
             }
         }
+
+        if stopped_thread.is_none() {
+            error!("Process stopped without a stopped thread. This is probably a bug. Ignoring.");
+            return;
+        }
+
         // Analyze stop reason
         let (stop_reason_str, description) = match stopped_thread {
             Some(ref stopped_thread) => {


### PR DESCRIPTION
I've been using this extension for a couple of years now and one thing that I've always found curious is that every time I use it to connect to my QEMU's gdbserver, the initial VSCode debugger UI state is out of sync, that is to say VSCode thinks the VM is paused when it is actually running. I have to press the "continue" button once just to make it be in sync again.

I've dived in my CodeLLDB logs and it looks like, on gdb-remote attachment, LLDB notifies of a pause and of a continue really really fast. CodeLLDB sends DAG notifications for both events, in order, but they must be somehow too fast for VSCode to handle them correctly such that VSCode essentially ignores the "continued" event and only remembers the "stopped" event.

I found that the stopped event was weird anyway since it did not contain any stop reason. Indeed, by the time notify_process_stopped() is called, all thread have already continued executing and it can't find a stopped thread.

As a workaround for my problem and a hint for future debugging, this introduces a bail out condition to notify_process_stopped(). If no stopped thread can be found, something is fishy anyway, no point notifying VSCode and getting into a corrupted state.