### PR TITLE
Improve summary printing

### DIFF
--- a/adapter/src/debug_session/variables.rs
+++ b/adapter/src/debug_session/variables.rs
@@ -384,7 +384,7 @@ impl super::DebugSession {
             }
 
             if let Some(name) = child.name() {
-                if let Some(Ok(value)) = child.value().map(|s| s.to_str()) {
+                if let Some(Ok(value)) = child.summary().or_else(|| child.value()).map(|s| s.to_str()) {
                     if name.starts_with("[") {
                         log_errors!(write!(summary, "{}{}", sep, value));
                     } else {


### PR DESCRIPTION
Before, it could happen that a child doesn't have a value, so it would
be omitted from the summary. Similarly, it can happen that a child
doesn't have a summary but has a value.

Now, we first try the summary and fall back to the value.

Without this change, when printing this struct in a log point using `"foo is {foo}"` we would just get `"foo is {...}"`:
```
struct Foo {
    bar: String,
}
```

With the fix, we get `"foo is {bar:"a string"}"`

While we were at it, we also bumped `MAX_LENGTH` to 512 but I'm not married to that.