### PR TITLE
954: don't quit capturing a stacktrace when we encounter an invalid frame

### DIFF
--- a/adapter/src/debug_session.rs
+++ b/adapter/src/debug_session.rs
@@ -659,9 +659,6 @@ impl DebugSession {
         let mut stack_frames = vec![];
         for i in start_frame..(start_frame + levels) {
             let frame = thread.frame_at_index(i as u32);
-            if !frame.is_valid() {
-                break;
-            }
 
             let key = format!("[{},{}]", thread.index_id(), i);
             let handle = self.var_refs.create(None, &key, Container::StackFrame(frame.clone()));
@@ -676,7 +673,7 @@ impl DebugSession {
                 format!("{:X}", pc_address.file_address())
             };
 
-            if !self.in_disassembly(&frame) {
+            if !frame.is_valid() || !self.in_disassembly(&frame) {
                 if let Some(le) = frame.line_entry() {
                     let fs = le.file_spec();
                     if let Some(local_path) = self.map_filespec_to_local(&fs) {

--- a/debuggee/cpp/debuggee.cpp
+++ b/debuggee/cpp/debuggee.cpp
@@ -169,6 +169,11 @@ int main(int argc, char *argv[])
     {
         *(volatile int *)0 = 42;
     }
+    else if (testcase == "crash_invalid_call")
+    {
+        using call_t = void(*)();
+        ((call_t)(nullptr))();
+    }
     else if (testcase == "throw")
     {
         throw std::runtime_error("error");

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -307,6 +307,12 @@ function generateSuite(triple: string) {
                 assert.equal(response4.body.variables[0].value, '20');
             });
 
+            test('invalid jump crash', async function () {
+                let stoppedEvent = await ds.launchAndWaitForStop({ name: 'invalid jump crash', program: debuggee, args: ['crash_invalid_call'] });
+                let response2 = await ds.stackTraceRequest({ threadId: stoppedEvent.body.threadId, startFrame: 20, levels: 10 });
+                assert.equal(response2.body.stackFrames.length, 10)
+            });
+
             test('variables', async function () {
                 let bpLine = findMarker(debuggeeTypes, '#BP3');
                 let stoppedEvent = await ds.launchAndWaitForStop({ name: 'variables', program: debuggee, args: ['vars'] },

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -309,8 +309,11 @@ function generateSuite(triple: string) {
 
             test('invalid jump crash', async function () {
                 let stoppedEvent = await ds.launchAndWaitForStop({ name: 'invalid jump crash', program: debuggee, args: ['crash_invalid_call'] });
-                let response2 = await ds.stackTraceRequest({ threadId: stoppedEvent.body.threadId, levels: 2 });
-                assert.equal(response2.body.stackFrames.length, 2)
+                let response = await ds.stackTraceRequest({ threadId: stoppedEvent.body.threadId, levels: 2 });
+                assert.equal(response.body.stackFrames.length, 2)
+                assert.equal(response.body.stackFrames[0].instructionPointerReference, '0x0');
+                assert.notEqual(response.body.stackFrames[1].instructionPointerReference, '0x0');
+                assert.equal(response.body.stackFrames[1].name, 'main');
             });
 
             test('variables', async function () {

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -309,8 +309,8 @@ function generateSuite(triple: string) {
 
             test('invalid jump crash', async function () {
                 let stoppedEvent = await ds.launchAndWaitForStop({ name: 'invalid jump crash', program: debuggee, args: ['crash_invalid_call'] });
-                let response2 = await ds.stackTraceRequest({ threadId: stoppedEvent.body.threadId, startFrame: 20, levels: 10 });
-                assert.equal(response2.body.stackFrames.length, 10)
+                let response2 = await ds.stackTraceRequest({ threadId: stoppedEvent.body.threadId, levels: 2 });
+                assert.equal(response2.body.stackFrames.length, 2)
             });
 
             test('variables', async function () {


### PR DESCRIPTION
Fixes #954 

Also add a test that covers this case