### PR TITLE
Fix typo in prompt

### DIFF
--- a/extension/main.ts
+++ b/extension/main.ts
@@ -477,7 +477,7 @@ class Extension implements DebugConfigurationProvider, DebugAdapterDescriptorFac
         if (address == undefined) {
             let addressStr = await window.showInputBox({
                 title: 'Enter memory address',
-                prompt: 'Hex, octal or decmal '
+                prompt: 'Hex, octal or decimal '
             });
             try {
                 address = BigInt(addressStr);


### PR DESCRIPTION
Hey folks! Thank you for the amazing plugin!

I have a tiny PR here that fixes a small typo in the prompt displayed when running the "View Memory" command:
![CleanShot 2023-08-01 at 17 14 52@2x](https://github.com/vadimcn/codelldb/assets/896486/1b689e3e-9e66-4402-95c9-a8d05a700f39)

