### PR TITLE
Fix exclude-callers in Devcontainer environment

### DIFF
--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -30,6 +30,7 @@ tokio-util = { version = "0.6.0", features = ["codec"] }
 lldb = { path = "crates/lldb" }
 loading = { path = "crates/loading" }
 adapter_protocol = { package = "adapter-protocol", path = "crates/adapter-protocol" }
+regex = "1.9.3"
 
 [target.'cfg(unix)'.dependencies]
 termios = "0.3.1"

--- a/adapter/src/debug_session/breakpoints.rs
+++ b/adapter/src/debug_session/breakpoints.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use regex::Regex;
+
 use adapter_protocol::*;
 use lldb::*;
 
@@ -824,7 +826,9 @@ impl DebugSession {
     fn symbol_from_location(&self, source: &Either<String, i64>, line: u32, column: Option<u32>) -> Option<String> {
         let bp2 = match source {
             Either::First(file_path) => {
-                let file_path_norm = normalize_path(Path::new(file_path));
+                let re = Regex::new(r"^vscode-remote://[^/]*").unwrap();
+                let trimmed_path = re.replace(file_path, "");
+                let file_path_norm = normalize_path(trimmed_path.as_ref());
                 self.target.breakpoint_create_by_location(&file_path_norm, line, column)
             }
             Either::Second(source_ref) => {


### PR DESCRIPTION
In a devcontainer environment (and maybe in remote-ssh as well), the file paths provided in the ExcludeCallerRequest appear to be prefixed with "vscode-remote://<identifier>". This messes up the logic for determining the symbol to be excluded.

This attempts to fix the problem by stripping off any such prefix.