### PR TITLE
support case of cargo outputting empty lines

### DIFF
--- a/extension/cargo.ts
+++ b/extension/cargo.ts
@@ -286,7 +286,11 @@ export class Cargo {
             let rl = readline.createInterface({ input: cargo.stdout });
             rl.on('line', line => {
                 try {
-                    onStdoutJson(JSON.parse(line));
+                    if (line.trim() === "") {
+                        onStdoutJson({});
+                    } else {
+                        onStdoutJson(JSON.parse(line));
+                    }
                 } catch (err) {
                     reject(new ErrorWithCause(`Could not parse JSON: "${line}"`, { cause: err }));
                 }


### PR DESCRIPTION
When trying to debug a unit test from the [parry](https://github.com/dimforge/parry) rust crate, I got an error in the codelldb vscode extension. Here was my launch config:

```json
{
  "type": "lldb",
  "request": "launch",
  "name": "Debug unit tests in library 'parry3d'",
  "cargo": {
    "args": [
      "test",
      "--package=parry3d"
    ],
    "filter": {
      "name": "parry3d",
      "kind": "lib"
    }
  },
  "args": [],
  "cwd": "${workspaceFolder}"
}
```

and here was the error:

```sh
Running `cargo test --package=parry3d --message-format=json`...
Error: Cargo invocation failed.
    at t.Cargo.getCargoArtifacts (/home/david/.vscode/extensions/vadimcn.vscode-lldb-1.9.2/extension.js:1:15379)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Object.open (/home/david/.vscode/extensions/vadimcn.vscode-lldb-1.9.2/extension.js:1:13689)
Caused by: Error: Could not parse JSON: ""
    at Interface.<anonymous> (/home/david/.vscode/extensions/vadimcn.vscode-lldb-1.9.2/extension.js:1:16948)
    at Interface.emit (node:events:513:28)
    at Interface._onLine (node:readline:491:10)
    at Interface._normalWrite (node:readline:665:12)
    at Socket.ondata (node:readline:272:10)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```

I suspect this is caused by the new lines added at the end of the message but I'm not sure