### PR TITLE
Add support for pickProcess with remote debugging via platformInitCommands

### DIFF
--- a/extension/main.ts
+++ b/extension/main.ts
@@ -64,8 +64,8 @@ class Extension implements DebugConfigurationProvider, DebugAdapterDescriptorFac
 
         subscriptions.push(commands.registerCommand('lldb.diagnose', () => this.runDiagnostics()));
         subscriptions.push(commands.registerCommand('lldb.getCargoLaunchConfigs', () => this.getCargoLaunchConfigs()));
-        subscriptions.push(commands.registerCommand('lldb.pickMyProcess', () => pickProcess(context, false)));
-        subscriptions.push(commands.registerCommand('lldb.pickProcess', () => pickProcess(context, true)));
+        subscriptions.push(commands.registerCommand('lldb.pickMyProcess', (config) => pickProcess(context, false, config)));
+        subscriptions.push(commands.registerCommand('lldb.pickProcess', (config) => pickProcess(context, true, config)));
         subscriptions.push(commands.registerCommand('lldb.attach', () => this.attach()));
         subscriptions.push(commands.registerCommand('lldb.alternateBackend', () => this.alternateBackend()));
         subscriptions.push(commands.registerCommand('lldb.commandPrompt', () => this.commandPrompt()));


### PR DESCRIPTION
I'd love to be able to use `${command:pickProcess}` with remote debugging to Android but that currently did not work because the `platform process list` command issued by pickProcess does not let you specify the remote platform.

This is a proposal to have a "platformInitCommands" list that is used both in debugger setup and in pickProcess to let you select/connect the platform.

Here's an example of using `"pid": "${command:pickProcess}" when debugging on an Android emulator:

![image](https://github.com/vadimcn/codelldb/assets/444248/e2599d94-23d5-47bc-aafe-dc8a8ecf78aa)
