### PR TITLE
Add filter option to pickProcess command

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -152,6 +152,50 @@ Flow during the attach sequence:
 Note that attaching to a running process may be [restricted](https://en.wikipedia.org/wiki/Ptrace#Support)
 on some systems.  You may need to adjust system configuration to enable it.
 
+### Pick Process Command
+
+The `${command:pickProcess}` or `${command:pickMyProcess}` can be used directly in the configuration for an interactive
+list of processes running on the machine running Visual Studio Code:
+
+```javascript
+{
+    "name": "Pick Process Attach",
+    "type": "lldb",
+    "request": "attach",
+    "pid": "${command:pickProcess}" // Or pickMyProcess for only processes for the current user.
+}
+```
+
+The `lldb.pickProcess` and `lldb.pickMyProcess` commands provide more configuration when used with input variables. The
+optional `initCommands` arg let you specify lldb commands to configure a remote connection. The optional `filter` arg
+lets you filter the process list to those that match the specified filter.
+
+```javascript
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Filtered Remote Attach",
+      "type": "lldb",
+      "request": "attach",
+      "pid": "${input:pickExampleProcess}",
+      "initCommands": [ ... ], // Eg, platform select/connect commands.
+    },
+  ],
+  "inputs": [
+    {
+      "id": "pickExampleProcess",
+      "type": "command",
+      "command": "lldb.pickProcess",
+      "args": {
+        "initCommands": [ ], // Eg., platform select/connect commands.
+        "filter": "example" // RegExp to filter processes to.
+      }
+    }
+  ]
+}
+```
+
 ## Custom Launch
 
 The custom launch method allows user to fully specify how the debug session is initiated:

--- a/extension/main.ts
+++ b/extension/main.ts
@@ -64,8 +64,8 @@ class Extension implements DebugConfigurationProvider, DebugAdapterDescriptorFac
 
         subscriptions.push(commands.registerCommand('lldb.diagnose', () => this.runDiagnostics()));
         subscriptions.push(commands.registerCommand('lldb.getCargoLaunchConfigs', () => this.getCargoLaunchConfigs()));
-        subscriptions.push(commands.registerCommand('lldb.pickMyProcess', () => pickProcess(context, false)));
-        subscriptions.push(commands.registerCommand('lldb.pickProcess', () => pickProcess(context, true)));
+        subscriptions.push(commands.registerCommand('lldb.pickMyProcess', (config) => pickProcess(context, false, config)));
+        subscriptions.push(commands.registerCommand('lldb.pickProcess', (config) => pickProcess(context, true, config)));
         subscriptions.push(commands.registerCommand('lldb.attach', () => this.attach()));
         subscriptions.push(commands.registerCommand('lldb.alternateBackend', () => this.alternateBackend()));
         subscriptions.push(commands.registerCommand('lldb.commandPrompt', () => this.commandPrompt()));

--- a/package.json
+++ b/package.json
@@ -158,6 +158,11 @@
 				"title": "Remove All Caller Exclusions",
 				"command": "lldb.excludedCallers.removeAll",
 				"icon": "$(clear-all)"
+			},
+			{
+				"category": "LLDB",
+				"title": "Pick Process",
+				"command": "lldb.pickProcess"
 			}
 		],
 		"languages": [


### PR DESCRIPTION
I work in the Chromium code base which uses several different processes.

It'd be very convenient if the pickProcess list was filtered to just the processes I care about. 

Here's a potential change to let you filter the process list by using the existing "program" option.

Here's what I put in my launch config:

```
  "program": "org.chromium.chrome"
```

And here's the result:

![image](https://github.com/vadimcn/codelldb/assets/444248/394b0977-7afe-4826-9102-b8c088a24486)

Note, this builds on  #1001 to get the config in to pickProcess
