### PR TITLE
Evaluate request: return memory reference for integral values

### DIFF
--- a/adapter/codelldb/src/debug_session/variables.rs
+++ b/adapter/codelldb/src/debug_session/variables.rs
@@ -224,25 +224,7 @@ impl super::DebugSession {
             })
         };
 
-        let mem_ref = match self.client_caps.supports_memory_references {
-            Some(true) => {
-                match var.value_type() {
-                    // Assume that the register value is an address, and use that.
-                    // So users can dump memory, e.g. as the SP, RIP+offset, etc.
-                    ValueType::Register => Some(format!("0x{:X}", var.value_as_unsigned(0))),
-                    // TODO: if it's a literal and looks like an address (e.g. some
-                    // sort of integer, use that as the addres)
-                    _ => {
-                        let load_addr = var.load_address();
-                        match load_addr {
-                            lldb::INVALID_ADDRESS => None,
-                            _ => Some(format!("0x{:X}", load_addr)),
-                        }
-                    }
-                }
-            }
-            _ => None,
-        };
+        let mem_ref = self.get_mem_ref_for_var(var);
 
         let is_settable = match var.type_().basic_type() {
             BasicType::Char
@@ -455,6 +437,35 @@ impl super::DebugSession {
         Err(AsyncResponse(Box::new(future::ready(result))).into())
     }
 
+    fn get_mem_ref_for_var(&self, var: &SBValue) -> Option<String> {
+        match self.client_caps.supports_memory_references {
+            Some(true) => {
+                match var.value_type() {
+                    // Assume that the register value is an address, and use that.
+                    // So users can dump memory, e.g. as the SP, RIP+offset, etc.
+                    ValueType::Register => Some(format!("0x{:X}", var.value_as_unsigned(0))),
+                    ValueType::ConstResult => {
+                      // Looks like a constant. Check if it's 32 or 64 bits, and
+                      // well, assume it _could be_ memory...
+                      match var.byte_size() {
+                        4 => Some(format!("0x{:X}", var.value_as_unsigned(0))),
+                        8 => Some(format!("0x{:X}", var.value_as_unsigned(0))),
+                        _ => None,
+                      }
+                    }
+                    _ => {
+                        let load_addr = var.load_address();
+                        match load_addr {
+                            lldb::INVALID_ADDRESS => None,
+                            _ => Some(format!("0x{:X}", load_addr)),
+                        }
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
     fn handle_execute_command(
         &mut self,
         command: &str,
@@ -499,6 +510,7 @@ impl super::DebugSession {
                     result: self.get_var_summary(&sbval, handle.is_some()),
                     type_: sbval.display_type_name().map(|s| s.to_owned()),
                     variables_reference: handles::to_i64(handle),
+                    memory_reference: self.get_mem_ref_for_var(&sbval),
                     ..Default::default()
                 })
             }


### PR DESCRIPTION
If the evaluation result looks like an integer literal, then provide that as a memory reference, allowing the user to dump arbitrary addresses e.g. by typing htem in or casting some variable to (void*).

---

In general, given an explicit memory value, we can now "dump" memory at that address, so say we have the following code:

```
  unsigned char data[1024];
  Foo f{ 10, 20, 30.7f };

  memcpy(data + 3, &f, sizeof(Foo));
```

We may want to inspect the memory pointed to by `data`. If we put `data` in the evaluator, we get a stringified representation. Instead we can put `(void*)data` or just the actual integral value and the result can be used with the "read memory" request to view the output:

```
Watches: ----
Expression: (void*)data
 *- Result: 0x000000016fdfe8d8

```

```
Memory at address 0x000000016fdfe8d8
--------------------------------------------------------------------------------------
Address             Bytes                                             Text
--------------------------------------------------------------------------------------
0x000000016FDFE8D8: 00 00 00 0A 00 00 00 00  00 00 00 14 00 00 00 00  ................
0x000000016FDFE8E8: 00 00 00 9A 99 F5 41 00  00 00 00 00 00 00 00 00  ......A.........
0x000000016FDFE8F8: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
0x000000016FDFE908: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
0x000000016FDFE918: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
0x000000016FDFE928: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
0x000000016FDFE938: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................

```