### PR TITLE
Add full support for data breakpoints

### DIFF
--- a/adapter/adapter-protocol/src/debugAdapterProtocol.json
+++ b/adapter/adapter-protocol/src/debugAdapterProtocol.json
@@ -1386,6 +1386,18 @@
 				"name": {
 					"type": "string",
 					"description": "The name of the Variable's child to obtain data breakpoint information for.\nIf variablesReference isn't provided, this can be an expression."
+				},
+				"frameId": {
+					"type": "integer",
+					"description": "When `name` is an expression, evaluate it in the scope of this stack frame. If not specified, the expression is evaluated in the global scope. When `variablesReference` is specified, this property has no effect."
+				},
+				"asAddress": {
+					"type": "boolean",
+					"description": "If `true`, the `name` is a memory address and the debugger should interpret it as a decimal value, or hex value if it is prefixed with `0x`.  Clients may set this property only if the `supportsDataBreakpointBytes` capability is true."
+				},
+				"bytes": {
+					"type": "integer",
+                                        "description": "If specified, a debug adapter should return information for the range of memory extending `bytes` number of bytes from the address or variable specified by `name`. Breakpoints set using the resulting data ID should pause on data access anywhere within that range. Clients may set this property only if the `supportsDataBreakpointBytes` capability is true."
 				}
 			},
 			"required": [ "name" ]
@@ -3145,7 +3157,11 @@
 				"supportsSingleThreadExecutionRequests": {
 					"type": "boolean",
 					"description": "The debug adapter supports the 'singleThread' property on the execution requests ('continue', 'next', 'stepIn', 'stepOut', 'reverseContinue', 'stepBack')."
-				}
+				},
+                                "supportsDataBreakpointBytes": {
+					"type": "boolean",
+					"description": "The debug adapter supports the `asAddress` and `bytes` fields in the `dataBreakpointInfo` request."
+                                }
 			}
 		},
 

--- a/adapter/codelldb/src/debug_session.rs
+++ b/adapter/codelldb/src/debug_session.rs
@@ -1054,27 +1054,19 @@ impl DebugSession {
             if let Some(child) = child {
                 let addr = child.load_address();
                 if addr != lldb::INVALID_ADDRESS {
-                    let size = child.byte_size();
-                    if self.is_valid_watchpoint_size(size) {
-                        let data_id = format!("{}/{}", addr, size);
-                        let desc = child.name().unwrap_or("");
-                        Ok(DataBreakpointInfoResponseBody {
-                            data_id: Some(data_id),
-                            access_types: Some(vec![
-                                DataBreakpointAccessType::Read,
-                                DataBreakpointAccessType::Write,
-                                DataBreakpointAccessType::ReadWrite,
-                            ]),
-                            description: format!("{} bytes at {:X} ({})", size, addr, desc),
-                            ..Default::default()
-                        })
-                    } else {
-                        Ok(DataBreakpointInfoResponseBody {
-                            data_id: None,
-                            description: "Invalid watchpoint size.".into(),
-                            ..Default::default()
-                        })
-                    }
+                    let size = args.bytes.unwrap_or(child.byte_size() as i64) as usize;
+                    let data_id = format!("{}/{}", addr, size);
+                    let desc = child.name().unwrap_or("");
+                    Ok(DataBreakpointInfoResponseBody {
+                        data_id: Some(data_id),
+                        access_types: Some(vec![
+                            DataBreakpointAccessType::Read,
+                            DataBreakpointAccessType::Write,
+                            DataBreakpointAccessType::ReadWrite,
+                        ]),
+                        description: format!("{} bytes at {:X} ({})", size, addr, desc),
+                        ..Default::default()
+                    })
                 } else {
                     Ok(DataBreakpointInfoResponseBody {
                         data_id: None,
@@ -1120,12 +1112,6 @@ impl DebugSession {
                         description: format!("Invalid address {}", addr),
                         ..Default::default()
                     })
-                } else if self.is_valid_watchpoint_size(size) {
-                    Ok(DataBreakpointInfoResponseBody {
-                        data_id: None,
-                        description: format!("Invalid size {} for watchpoint", size),
-                        ..Default::default()
-                    })
                 } else {
                     Ok(DataBreakpointInfoResponseBody {
                         data_id: Some(format!("{}/{}", addr, size)),
@@ -1145,26 +1131,18 @@ impl DebugSession {
                 let addr = result.load_address();
                 if addr != lldb::INVALID_ADDRESS {
                     let size = args.bytes.unwrap_or(result.byte_size() as i64) as usize;
-                    if self.is_valid_watchpoint_size(size) {
-                        let data_id = format!("{}/{}", addr, size);
-                        let desc = result.name().unwrap_or(expr);
-                        Ok(DataBreakpointInfoResponseBody {
-                            data_id: Some(data_id),
-                            access_types: Some(vec![
-                                DataBreakpointAccessType::Read,
-                                DataBreakpointAccessType::Write,
-                                DataBreakpointAccessType::ReadWrite,
-                            ]),
-                            description: format!("{} bytes at {:X} ({})", size, addr, desc),
-                            ..Default::default()
-                        })
-                    } else {
-                        Ok(DataBreakpointInfoResponseBody {
-                            data_id: None,
-                            description: format!("Expression '{}' results in invalid watchpoint size: {}.", expr, size),
-                            ..Default::default()
-                        })
-                    }
+                    let data_id = format!("{}/{}", addr, size);
+                    let desc = result.name().unwrap_or(expr);
+                    Ok(DataBreakpointInfoResponseBody {
+                        data_id: Some(data_id),
+                        access_types: Some(vec![
+                            DataBreakpointAccessType::Read,
+                            DataBreakpointAccessType::Write,
+                            DataBreakpointAccessType::ReadWrite,
+                        ]),
+                        description: format!("{} bytes at {:X} ({})", size, addr, desc),
+                        ..Default::default()
+                    })
                 } else {
                     Ok(DataBreakpointInfoResponseBody {
                         data_id: None,
@@ -1173,21 +1151,6 @@ impl DebugSession {
                     })
                 }
             }
-        }
-    }
-
-    fn is_valid_watchpoint_size(&self, size: usize) -> bool {
-        let addr_size = self.target.address_byte_size();
-        match addr_size {
-            4 => match size {
-                1 | 2 | 4 => true,
-                _ => false,
-            },
-            8 => match size {
-                1 | 2 | 4 | 8 => true,
-                _ => false,
-            },
-            _ => true, // No harm in allowing to set an invalid watchpoint, other than user confusion.
         }
     }
 

--- a/adapter/codelldb/src/debug_session/variables.rs
+++ b/adapter/codelldb/src/debug_session/variables.rs
@@ -533,6 +533,20 @@ impl super::DebugSession {
         }
     }
 
+    pub fn evaluate_user_supplied_expr(
+      &self,
+      expression: &str,
+      frame: Option<SBFrame>,
+    ) -> Result<SBValue, Error> {
+        // The format spec is ignored and dropped, because the purpose of this
+        // fn is to just return the SBValue to get references for things like
+        // data breakpoints
+        let (pp_expr, _format_spec) =
+            expressions::prepare_with_format(expression, self.default_expr_type).map_err(blame_user)?;
+        self.evaluate_expr_in_frame(&pp_expr, frame.as_ref())
+    }
+
+
     // Evaluates expr in the context of frame (or in global context if frame is None)
     // Returns expressions.Value or SBValue on success, SBError on failure.
     pub(super) fn evaluate_expr_in_frame(

--- a/adapter/lldb/src/sb/sbtarget.rs
+++ b/adapter/lldb/src/sb/sbtarget.rs
@@ -164,7 +164,21 @@ impl SBTarget {
         let mut error = SBError::new();
         let wp = cpp!(unsafe [self as "SBTarget*", addr as "addr_t", size as "size_t",
                      read as "bool", write as "bool", mut error as "SBError"] -> SBWatchpoint as "SBWatchpoint" {
-            return self->WatchAddress(addr, size, read, write, error);
+
+            //
+            // The LLDB API WatchAddress is a wrapper for
+            // WatchpointCreateByAddress, but it's bugged and ignores what you
+            // put in 'modify', meaning it always stops even for read-only
+            // breakpoing requests. Fortunately, the implementation is trivial,
+            // so we can just call WatchpointCreateByAddress directly.
+            //
+            SBWatchpointOptions options = {};
+            options.SetWatchpointTypeRead(read);
+            if (write) {
+              options.SetWatchpointTypeWrite(eWatchpointWriteTypeOnModify);
+            }
+
+            return self->WatchpointCreateByAddress(addr, size, options, error);
         });
         if error.is_success() {
             Ok(wp)


### PR DESCRIPTION
RFC - Opening this to see if you're interested in the contribution. I'm working on [implementing data breakpoints in vimspector](https://github.com/puremourning/vimspector/pull/765), and as always it's much easier to hack codelldb than anything else, so I implemented the extra features from DAP spec. Only lightly tested at this point.

----

Currently, we only provode support for data breakpoints where the request is for a child of some container using variables_reference. However, the spec includes support for:

- an arbitrary expression, and
- an arbitrary address, and
- an optional size in bytes.

The later two are supported via a capability
"supportsDataBreakpointBytes". We add support for all of these options.

It's fairly trivial to evaluate an expression and do esentially what we do now for children (find the load address, check its size). But we can also accept a size, so long as it's valid watchpoint size. Similarly for addresses, if 'asAddress' is supplied we can just try to use it. It will probably fail if the address is actually invalid, but that's sort of the point.