### PR TITLE
Added: Small note for debugging build scripts.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -258,6 +258,13 @@ std::process::Command::new("code").arg("--open-url").arg(url).output().unwrap();
 std::thread::sleep_ms(1000); // Wait for debugger to attach
 ```
 
+(Note: You may need to update your `Cargo.toml` to build the build script with `debug`.)
+
+```
+[profile.dev.build-override]
+debug = true
+```
+
 ### Debugging Rust unit tests
 - Create `.cargo` directory in your project folder containing these two files:
     - `config` [(see also)](https://doc.rust-lang.org/cargo/reference/config.html)


### PR DESCRIPTION
Build scripts built on release builds may be undebuggable with more modern versions of rust.

So we should inform how to fallback to debug.