### PR TITLE
[MacOS] Include header files when building from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build*/
 /target/
 *.pyc
+node_modules/**

--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -20,6 +20,8 @@ else()
     file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/lib)
     file(CREATE_LINK ${LLDB_PACKAGE}/bin ${CMAKE_CURRENT_BINARY_DIR}/bin SYMBOLIC)
     file(CREATE_LINK ${LLDB_PACKAGE}/lib ${CMAKE_CURRENT_BINARY_DIR}/lib SYMBOLIC)
+    file(CREATE_LINK ${LLDB_PACKAGE}/../lldb/include ${CMAKE_CURRENT_BINARY_DIR}/include SYMBOLIC)
+    file(CREATE_LINK ${CMAKE_CURRENT_BINARY_DIR}/include/API/SBLanguages.h ${CMAKE_CURRENT_BINARY_DIR}/include/lldb/API/SBLanguages.h SYMBOLIC)
 
     # Don't check dependencies in symlinked LLDB, as it contains many files that won't be included in the package.
 endif()


### PR DESCRIPTION
I created a zip file from existing extension `lldb` folder.
Tried running cmake to build from source - with lots of trouble ( complaining about missing `libc++abi` and what not ) but succesful in the end.
Then `make adapter` complained about missing headers : `LLDB.h`.
possibly because the zipped `lldb` folder didn't have an include directory.

So tried setting `LLDB_PACKAGE` to llvm build folder.
same results.
so ended up modifying these cmake script to copy include files similar to bin and lib files in Cmake script.

i might be missing something here - maybe a `LLDB_INCLUDE` environment variable. 
anyway can be helpful to keep in google's indexes.



Ohh and btw @vadimcn thanks for the extension - i have really enjoyed using it for last couple of months.