### PR TITLE
Fix i8/u8 variable formatting

### DIFF
--- a/lang_support/rust.py
+++ b/lang_support/rust.py
@@ -11,7 +11,8 @@ def __lldb_init_module(debugger, internal_dict):  # pyright: ignore
     lldb.SBDebugger.SetInternalVariable('target.process.thread.step-avoid-regexp',
                                         '^<?(std|core|alloc)::', debugger.GetInstanceName())
 
-    debugger.HandleCommand("type format add --category Rust --format dec 'char' 'unsigned char'")
+    debugger.HandleCommand("type format add --category Rust --format d 'char' 'signed char'")
+    debugger.HandleCommand("type format add --category Rust --format u 'unsigned char'")
 
     sysroot = codelldb.get_config('lang.rust.sysroot')
     if sysroot is None:


### PR DESCRIPTION
This fixes 2 minor issues:

* u8's >= 128 currently get formatted as negative numbers
* i8 does not get any formatting override since LLDB reads them as `signed char` rather than just `char` (i left in `char` though just to be safe). 