### PR TITLE
Update documentation for inspecting a core dump

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -399,6 +399,7 @@ Use launch configuration with `target create -c <core path>` command:
     "name": "Core dump",
     "type": "lldb",
     "request": "launch",
+    "processCreateCommands": [],
     "targetCreateCommands": ["target create -c ${workspaceFolder}/core"],
 }
 ```


### PR DESCRIPTION
Add empty `"processCreateCommands": []` to documentation about inspecting a core file. Otherwise, the result as described in #1245 can occur.