### PR TITLE
adapter: Apply launch delay only to vscode clients

### DIFF
--- a/adapter/codelldb/src/debug_session/launch.rs
+++ b/adapter/codelldb/src/debug_session/launch.rs
@@ -50,9 +50,12 @@ impl super::DebugSession {
         let mut config_done_recv = self.configuration_done_sender.subscribe();
         let self_ref = self.self_ref.clone();
         let fut = async move {
-            // Work around https://github.com/microsoft/vscode/issues/231074 by pausing before sending the
-            // `runInTerminal` message.  This gives VSCode the chance to process `output` messages we sent earlier.
-            tokio::time::sleep(time::Duration::from_millis(100)).await;
+            if self_ref.map(|s| s.client_caps.client_id.as_deref() == Some("vscode")).await {
+                // Work around https://github.com/microsoft/vscode/issues/231074 by pausing before sending the
+                // `runInTerminal` message.  This gives VSCode the chance to process `output` messages we sent earlier.
+                tokio::time::sleep(time::Duration::from_millis(100)).await;
+            }
+
             log_errors!(config_done_recv.recv().await);
             self_ref.map(|s| s.create_terminal(&args)).await.await;
             self_ref.map(|s| s.complete_launch(args)).await


### PR DESCRIPTION
This commit gates the artificial delay in launch request, as it's not needed for clients other than VSC (e.g. in Zed).