### PR TITLE
Set stdio values to None when given an empty string

### DIFF
--- a/adapter/codelldb/src/debug_session/launch.rs
+++ b/adapter/codelldb/src/debug_session/launch.rs
@@ -428,6 +428,16 @@ impl super::DebugSession {
             Some(Either::First(ref stdio)) => vec![Some(stdio.clone())], // A single string
             Some(Either::Second(ref stdio)) => stdio.clone(),            // List of strings
         };
+
+        // replace empty strings with None
+        for entry in stdio.iter_mut() {
+            if let Some(path) = entry {
+                if path.is_empty() {
+                    *entry = None;
+                }
+            }
+        }
+
         // Pad to at least 3 entries
         while stdio.len() < 3 {
             stdio.push(None)


### PR DESCRIPTION
This will give an option output to the default device hen using inputs in `launch.json`.
For example:
```jsonc
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "lldb",
            "request": "launch",
            // ...
            "stdio": [
                null,
                "${input:stdoutFile}",
                null
            ],
            // ...
        }
    ],
    "inputs": [
        {
            "id": "stdoutFile",
            "type": "promptString",
            "description": "Path to STDOUT file",
        }
    ]
}
```
In this case, when stdoutFile is not set by the user stdio will be:
```jsonc
"stdio": [
    null,
    "",
    null
],
```
This will result in an error.

To counteract this, the change I made replaces empty strings with None.