### PR TITLE
Fix 'no available capacity' error by increasing queue size.

### DIFF
--- a/adapter/codelldb/src/debug_session.rs
+++ b/adapter/codelldb/src/debug_session.rs
@@ -182,8 +182,11 @@ impl DebugSession {
         debug_session.update_adapter_settings(&settings);
 
         let mut requests_receiver = DebugSession::cancellation_filter(&debug_session.dap_session.clone());
+        // The debug event listener is used to receive events from the debugger.
+        // For very large code bases, the number of events can be quite large so the channel size has been set to 2^17
+        // to avoid dropping events.
         let mut debug_events_stream =
-            debug_session.debug_event_listener.start_polling(&debug_session.debugger.listener(), 1000);
+            debug_session.debug_event_listener.start_polling(&debug_session.debugger.listener(), 131072);
 
         let con_writer = debug_session.console_pipe.try_clone().unwrap();
         log_errors!(debug_session.debugger.set_output_file(SBFile::from(con_writer, false)));


### PR DESCRIPTION
This PR increases the debug event channel size to avoid dropping events in large code bases.

Should should resolve #1273, #1040, and #1010.

Fixes #1273.

## Verification Evidence

I made my changes, then ran the following:

```
mkdir build
cd build
cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-aarch64-apple-darwin.cmake -DLLDB_PACKAGE=/Users/stu/Downloads/lldb--aarch64-apple-darwin.zip
```
```
$ make vsix_full
Archive:  /Users/stu/Downloads/lldb--aarch64-apple-darwin.zip
[  0%] Built target lldb
[  3%] Built target extension
[ 11%] Built target lang_support
[ 15%] Performing build step for 'cargo_build'
   Compiling codelldb v1.0.0 (/Users/stu/dev/vadimcn/codelldb/adapter/codelldb)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.02s
[ 19%] No install step for 'cargo_build'
[ 23%] Completed 'cargo_build'
[ 42%] Built target cargo_build
[ 42%] Built target codelldb_exe
[ 76%] Built target codelldb_scripts
[ 76%] Built target adapter

> vscode-lldb@1.11.4-dev.2505021902 vsce
> vsce package --baseContentUrl https://github.com/vadimcn/codelldb/blob/v1.11.4-dev.2505021902 --baseImagesUrl https://github.com/vadimcn/codelldb/raw/v1.11.4-dev.2505021902 --target darwin-x64 -o /Users/stu/dev/vadimcn/codelldb/build/codelldb-full.vsix

 WARNING  LICENSE.md, LICENSE.txt or LICENSE not found
Do you want to continue? [y/N] Y
 DONE  Packaged: /Users/stu/dev/vadimcn/codelldb/build/codelldb-full.vsix (992 files, 43.46MB)
[100%] Built target vsix_full
```

I opened vscode and loaded the extension directly from the `.vsix` file.

Running the debugger now works as expected!

<img width="528" alt="Screenshot 2025-05-02 at 12 28 48 PM" src="https://github.com/user-attachments/assets/90b5ccb7-9aa4-43b8-928f-9ef1157ef887" />
