### PR TITLE
Improve verbose log formatting in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,9 +13,13 @@ Debuggee: <!-- What kind of a binary you are debugging? ❶ -->
 <!-- What is the problem and how did you get there -->
 
 <details> <!-- If reporting a debugger crash or an internal error, please consider providing a verbose log ❷ -->
-<summary>Verbose log</summary><pre>
-  <!-- Log goes here -->
-</pre></details>
+<summary>Verbose log</summary>
+
+```
+Log goes here
+```
+
+</details>
 
 
 <!--


### PR DESCRIPTION
Currently, the issue template causes the verbose log to be formatted weirdly if it includes things that look like Markdown formatting. For example, the log in #1302 mentions a file named `__init__.py`, but the current issue template using `<pre></pre>` causes GitHub to display the filename as <code><strong>init</strong>.py</code> instead. This PR fixes that.