### PR TITLE
Import Rust visualizer script even if `lldb_commands` is missing

### DIFF
--- a/lang_support/rust.py
+++ b/lang_support/rust.py
@@ -47,7 +47,7 @@ def __lldb_init_module(debugger, internal_dict):  # pyright: ignore
     log.info(f'Rust formatters dir: {formatters}')
     lldb_lookup = path.join(formatters, 'lldb_lookup.py')
     lldb_commands = path.join(formatters, 'lldb_commands')
-    if not path.isfile(lldb_lookup) or not path.isfile(lldb_commands):
+    if not path.isfile(lldb_lookup):
         message = 'Could not find LLDB data formatters in your Rust toolchain.'
         if sysroot and '-msvc' in sysroot:
             message += '  For more information, please visit https://github.com/vadimcn/codelldb/wiki/Windows'
@@ -56,6 +56,10 @@ def __lldb_init_module(debugger, internal_dict):  # pyright: ignore
 
     codelldb.debugger_message('Loading Rust formatters from {}'.format(formatters))
     debugger.HandleCommand("command script import '{}'".format(lldb_lookup))
+
+    if not path.isfile(lldb_commands):
+        return
+
     with open(lldb_commands, 'rt') as f:
         for line in f:
             line = line.strip()


### PR DESCRIPTION
per https://github.com/rust-lang/rust/pull/155336, Rust is planning to remove `lldb_commands` and register the visualizers through `__lldb_init_module` instead